### PR TITLE
feat(mixins): add docker-compose mixin

### DIFF
--- a/mixins/index.json
+++ b/mixins/index.json
@@ -24,6 +24,12 @@
     "URL": "https://github.com/deislabs/porter-cowsay/releases/download"
   },
   {
+    "name": "docker-compose",
+    "author": "Porter Authors",
+    "description": "A mixin for using the docker-compose cli",
+    "URL": "https://cdn.porter.sh/mixins/atom.xml"
+  },
+  {
     "name": "exec",
     "author": "Porter Authors",
     "description": "A mixin for executing shell commands",


### PR DESCRIPTION
Adds a listing for the [docker-compose](https://github.com/deislabs/porter-docker-compose) mixin

```shell 
$ porter mixin install docker-compose --feed-url https://cdn.porter.sh/mixins/atom.xml
installed docker-compose mixin v0.1.0-beta.1 (71e2666)
```