### PR TITLE
Rename the helm mixin to helm2

### DIFF
--- a/mixins/atom.xml
+++ b/mixins/atom.xml
@@ -16,8 +16,19 @@
     <category term="exec"/>
     <category term="gcloud"/>
     <category term="helm"/>
+    <category term="helm2"/>
     <category term="kubernetes"/>
     <category term="terraform"/>
+    <entry>
+        <id>https://cdn.porter.sh/mixins/helm2/v0.14.0</id>
+        <title>helm2 @ v0.14.0</title>
+        <updated>2021-06-30T21:09:13Z</updated>
+        <category term="helm2"/>
+        <content>v0.14.0</content>
+        <link rel="download" href="https://cdn.porter.sh/mixins/helm2/v0.14.0/helm2-darwin-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/helm2/v0.14.0/helm2-linux-amd64" />
+        <link rel="download" href="https://cdn.porter.sh/mixins/helm2/v0.14.0/helm2-windows-amd64.exe" />
+    </entry>
     <entry>
         <id>https://cdn.porter.sh/mixins/helm/v0.14.0</id>
         <title>helm @ v0.14.0</title>

--- a/mixins/index.json
+++ b/mixins/index.json
@@ -48,21 +48,21 @@
     "URL": "https://cdn.porter.sh/mixins/atom.xml"
   },
   {
-    "name": "helm",
+    "name": "helm2",
     "author": "Porter Authors",
-    "description": "A mixin for using the helm cli",
+    "description": "Deprecated, use Mohamed Chorfa's helm3 mixin instead. A mixin for using the helm v2 cli",
     "URL": "https://cdn.porter.sh/mixins/atom.xml"
   },
   {
     "name": "helm3",
     "author": "Ralph Squillace",
-    "description": "A mixin for using the helm 3 cli",
+    "description": "A mixin for using the helm v3 cli",
     "URL": "https://github.com/squillace/porter-helm3/releases/download"
   },
   {
     "name": "helm3",
     "author": "Mohamed Chorfa",
-    "description": "Porter Helm3 Mixin",
+    "description": "A mixin for using the helm v3 cli",
     "URL": "https://mchorfa.github.com/porter-helm3/atom.xml"
   },
   {


### PR DESCRIPTION
This removes "helm" from the results of `porter mixins search` and ensures that it shows up as helm2 instead. If someone was installing the mixin with `porter mixins install helm` that will continue to work because we have old entries in our atom.xml but they will get the last version of the helm mixin before we renamed it.

Part of https://github.com/getporter/helm-mixin/issues/81