### PR TITLE
Bump the vm image used in CI

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -7,7 +7,7 @@ pr:
   - main
 
 pool:
-  vmImage: 'Ubuntu 16.04'
+  vmImage: 'ubuntu-latest'
 
 stages:
 - stage: Test


### PR DESCRIPTION
We were using a fixed version of ubuntu that is no longer supported.
I've switched us over to using ubuntu-latest so that the build doesn't
break every few months.
