### PR TITLE
Add ansible mixin to mixin list

### DIFF
--- a/mixins/index.json
+++ b/mixins/index.json
@@ -88,5 +88,11 @@
     "author": "Porter Authors",
     "description": "A mixin for using the docker cli",
     "URL": "https://cdn.porter.sh/mixins/atom.xml"
+  },
+  {
+    "name": "ansible",
+    "author": "LvffY",
+    "description": "A mixin for using the ansible cli",
+    "URL": "https://github.com/LvffY/ansible-mixin/releases/download"
   }
 ]


### PR DESCRIPTION
Closes https://github.com/getporter/porter/issues/1060.

The code for the ansible mixin is at [LvffY/ansible-mixin](https://github.com/LvffY/ansible-mixin). Any review and or suggestions are welcome :)