### PR TITLE
Update plugin descriptions

### DIFF
--- a/plugins/index.json
+++ b/plugins/index.json
@@ -2,7 +2,7 @@
   {
     "name": "azure",
     "author": "Porter Authors",
-    "description": "Integrate Porter with Azure. Store Porter's data in Azure Cloud and secure your bundle's secrets in Azure Key Vault.",
+    "description": "Integrate Porter with Azure. Let you secure your bundle's secrets in Azure Key Vault.",
     "URL": "https://cdn.porter.sh/plugins/atom.xml"
   },
   {
@@ -14,7 +14,7 @@
   {
     "name": "kubernetes",
     "author": "Porter Authors",
-    "description": "Integrates Porter with Kubernetes. Store Porter's data and your bundle's secrets in Kubernetes Secret Resources.",
+    "description": "Integrates Porter with Kubernetes. Let you secure your bundle's secrets in Kubernetes Secret Resources.",
     "URL": "https://cdn.porter.sh/plugins/atom.xml"
   }
 ]

--- a/plugins/index.json
+++ b/plugins/index.json
@@ -2,19 +2,19 @@
   {
     "name": "azure",
     "author": "Porter Authors",
-    "description": "Integrate Porter with Azure. Let you secure your bundle's secrets in Azure Key Vault.",
+    "description": "Integrate Porter with Azure. Secure your bundle's secrets in Azure Key Vault.",
     "URL": "https://cdn.porter.sh/plugins/atom.xml"
   },
   {
     "name": "hashicorp",
     "author": "REDDY PRASAD",
-    "description": "Integrates Porter with Hashicorp services. Let you secure your bundle's secrets in Hashicorp's vault.",
+    "description": "Integrates Porter with Hashicorp services. Secure your bundle's secrets in Hashicorp's vault.",
     "URL": "https://github.com/dev-drprasad/porter-hashicorp-plugins/releases/download/feed/atom.xml"
   },
   {
     "name": "kubernetes",
     "author": "Porter Authors",
-    "description": "Integrates Porter with Kubernetes. Let you secure your bundle's secrets in Kubernetes Secret Resources.",
+    "description": "Integrates Porter with Kubernetes. Secure your bundle's secrets in Kubernetes Secret Resources.",
     "URL": "https://cdn.porter.sh/plugins/atom.xml"
   }
 ]


### PR DESCRIPTION
Update the description to be explicit that the Azure and Kubernetes plugin only is for secrets

Closes #27 