### PR TITLE
Remove kustomize mixin

### DIFF
--- a/mixins/index.json
+++ b/mixins/index.json
@@ -72,12 +72,6 @@
     "URL": "https://cdn.porter.sh/mixins/atom.xml"
   },
   {
-    "name": "kustomize",
-    "author": "Don Stewart",
-    "description": "A mixin for using the kustomize cli",
-    "URL": "https://github.com/donmstewart/porter-kustomize/releases/download"
-  },
-  {
     "name": "terraform",
     "author": "Porter Authors",
     "description": "A mixin for using the terraform cli",


### PR DESCRIPTION
The kustomize mixin seems to have disappeared as @donmstewart is [no longer active on GitHub](https://github.com/donmstewart).

https://github.com/donmstewart/porter-kustomize/releases/download results in 404 

