### PR TITLE
feat: add JSON Schema validation for package lists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ test:
 	@cat mixins/index.json | jq -r '.' > /dev/null
 	$(info validating plugins list is well-formed JSON)
 	@cat plugins/index.json | jq -r '.' > /dev/null
+	$(info validating mixins list against JSON Schema)
+	@npx --yes ajv-cli validate -s schema.json -d mixins/index.json
+	$(info validating plugins list against JSON Schema)
+	@npx --yes ajv-cli validate -s schema.json -d plugins/index.json
 
 .PHONY: publish
 publish:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,15 @@ The `URL` field should be one of the following:
 * **Atom Feed URL:** Porter uses the following for its stable plugins: `https://cdn.porter.sh/plugin/atom.xml`
 * **Download URL:** Directory where binaries are hosted, such as GitHub releases: `https://github.com/org/project/releases/download`
 
-To ensure proper formatting of the edited list, `make test` can be run.
+To ensure proper formatting of the edited list, `make test` can be run. This will:
+- Validate that the JSON is well-formed
+- Validate that the list conforms to the [JSON Schema](schema.json)
+
+The schema validates that each package entry has:
+- `name` (required, non-empty string)
+- `author` (required, non-empty string)
+- `description` (required, non-empty string)
+- `URL` (required, non-empty string starting with http:// or https://)
 
 When ready, open up a pull request with the updated directory.  Once merged,
 your mixin or plugin listing will be broadcast to the world!

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://porter.sh/schemas/packages.json",
+  "title": "Porter Package List",
+  "description": "Schema for Porter mixin and plugin package lists",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["name", "author", "description", "URL"],
+    "properties": {
+      "name": {
+        "type": "string",
+        "description": "The name of the mixin or plugin",
+        "minLength": 1
+      },
+      "author": {
+        "type": "string",
+        "description": "The author or maintainer of the package",
+        "minLength": 1
+      },
+      "description": {
+        "type": "string",
+        "description": "A brief description of what the package does",
+        "minLength": 1
+      },
+      "URL": {
+        "type": "string",
+        "description": "The URL to either an Atom feed or download directory for the package",
+        "minLength": 1,
+        "pattern": "^https?://"
+      }
+    },
+    "additionalProperties": false
+  },
+  "minItems": 1
+}


### PR DESCRIPTION
## Summary

Implements JSON Schema validation for mixin and plugin package lists as requested in #2.

## Changes

- **schema.json**: Added JSON Schema (Draft 7) that validates package list structure
- **Makefile**: Extended `test` target to validate lists against the schema using ajv-cli
- **README.md**: Documented the new validation requirements for contributors

## Validation Details

The schema enforces the following rules for each package entry:

- ✅ Required fields: `name`, `author`, `description`, `URL`
- ✅ All fields must be non-empty strings
- ✅ URLs must start with `http://` or `https://`
- ✅ No additional properties allowed
- ✅ At least one package entry required

## Testing

The validation runs automatically via:
- `make test` (local development)
- GitHub Actions CI workflow (on PRs and pushes)

Both existing package lists (mixins and plugins) pass validation successfully.

### Example Error Detection

The schema catches common errors:
```bash
# Missing required field
{"name":"test","author":"test","description":"test"}
# Error: must have required property 'URL'

# Empty string
{"name":"","author":"test","description":"test","URL":"http://example.com"}
# Error: must NOT have fewer than 1 characters

# Invalid URL
{"name":"test","author":"test","description":"test","URL":"not-a-url"}
# Error: must match pattern "^https?://"
```

## Implementation Notes

- Uses `ajv-cli` via npx (no additional dependencies to install)
- Maintains backward compatibility with existing validation
- Schema is reusable for both mixins and plugins (they share the same structure)

Closes #2